### PR TITLE
Ensure pushes to main in release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -59,6 +59,7 @@ jobs:
       uses: ad-m/github-push-action@v0.6.0
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
+        branch: main
 
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This ensures that distribution of the production-ready code goes to `main` rather than `master`.