### PR TITLE
Assign team individuals from teams until no team members remain

### DIFF
--- a/.github/workflows/run.yaml
+++ b/.github/workflows/run.yaml
@@ -33,8 +33,14 @@ jobs:
         id: get-number-of-reviewers
         run: |
           REVIEWERS=$(echo '${{ toJson(github.event.pull_request.requested_reviewers) }}' | jq '. | length')
-          echo $REVIEWERS
+          TEAMS=$(echo '${{ toJson(github.event.pull_request.requested_teams) }}' | jq '. | length')
+          TOTAL=$(($REVIEWERS + $TEAMS))
+          echo "Individual reviewers: $REVIEWERS"
+          echo "Team reviewers: $REVIEWERS"
+          echo "Total: $REVIEWERS"
           echo "::set-output name=reviewers::$REVIEWERS"
+          echo "::set-output name=teams::$TEAMS"
+          echo "::set-output name=total::$TOTAL"
 
       - name: Checkout
         uses: actions/checkout@v3
@@ -57,7 +63,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.REPO_TOKEN }}
 
       - name: Validate
-        if: steps.get-number-of-reviewers.outputs.reviewers < 1
+        if: steps.get-number-of-reviewers.outputs.total < 1
         uses: actions/github-script@v6
         with: 
           script: |

--- a/dist/assign.js
+++ b/dist/assign.js
@@ -97,14 +97,14 @@ const fetchTeamMembers = (organisation, codeowners) => async (octokit) => {
     return joined;
 };
 exports.fetchTeamMembers = fetchTeamMembers;
-const selectReviewers = async (changedFiles, codeowners, ownerTeams, options) => {
+const selectReviewers = async (changedFiles, codeowners, teamMembers, options) => {
     const { assignedReviewers, reviewers, assignIndividuals } = options;
     const selectedTeams = new Set();
     const selectedUsers = new Set();
     const assignees = () => selectedTeams.size + selectedUsers.size + assignedReviewers;
     const randomGlobalCodeowner = (owners) => (assignIndividuals ? owners?.[0] : owners?.shift());
     const stack = JSON.parse(JSON.stringify(codeowners)); //Poor man's deep clone.
-    const teams = ownerTeams && JSON.parse(JSON.stringify(ownerTeams));
+    const teams = teamMembers && JSON.parse(JSON.stringify(teamMembers));
     const globalCodeowners = stack.find(owner => owner.pattern === '*')?.owners;
     while (assignees() < reviewers) {
         const randomFile = randomize(changedFiles)?.[0];

--- a/dist/assign.js
+++ b/dist/assign.js
@@ -112,9 +112,13 @@ const selectReviewers = async (changedFiles, codeowners, ownerTeams, options) =>
             break;
         const teamSlug = extractTeamSlug(selected);
         if (isTeam(selected) && assignIndividuals) {
-            const randomTeamMember = randomize(teams?.[teamSlug])?.shift();
-            if (!randomTeamMember)
+            if (Object.keys(teams).length === 0)
                 break;
+            const randomTeamMember = randomize(teams?.[teamSlug])?.shift();
+            if (!randomTeamMember) {
+                delete teams?.[teamSlug];
+                continue;
+            }
             (0, core_1.info)(`Assigning '${randomTeamMember}' from assignee team '${teamSlug}'.`);
             selectedUsers.add(randomTeamMember);
         }

--- a/dist/assign.js
+++ b/dist/assign.js
@@ -150,6 +150,7 @@ const selectReviewers = async (changedFiles, codeowners, teamMembers, options) =
             selectedUsers.add(selected);
         }
     }
+    (0, core_1.info)(`Selected ${assignees()} of ${reviewers} assignees.`);
     return {
         count: assignees(),
         teams: Array.from(selectedTeams),

--- a/dist/assign.js
+++ b/dist/assign.js
@@ -184,7 +184,7 @@ const assignReviewers = (pullRequest, reviewers) => async (octokit) => {
         (0, core_1.info)(stringify(requested));
         return requested;
     }
-    return undefined;
+    return reviewers;
 };
 exports.assignReviewers = assignReviewers;
 const run = async () => {

--- a/dist/assign.js
+++ b/dist/assign.js
@@ -219,10 +219,6 @@ const run = async () => {
         const selected = await (0, exports.selectReviewers)(changedFiles, codeowners, teams, selectionOptions);
         (0, core_1.info)(`Selected additional reviewers for assignment: ${stringify(selected)}`);
         const assigned = await (0, exports.assignReviewers)(pullRequest, selected)(octokit);
-        if (!assigned) {
-            (0, core_1.error)(`Failed to assign reviewers: ${stringify(selected)}`);
-            process.exit(1);
-        }
         (0, core_1.setOutput)('assigned-codeowners', stringify(assigned));
         (0, core_1.info)(`Assigned reviewers: ${stringify(assigned)}`);
     }

--- a/dist/assign.js
+++ b/dist/assign.js
@@ -214,7 +214,7 @@ const run = async () => {
         const changedFiles = await (0, exports.extractChangedFiles)(assignFromChanges, pullRequest)(octokit);
         (0, core_1.info)('Selecting reviewers for assignment.');
         const selected = await (0, exports.selectReviewers)(changedFiles, codeowners, teams, selectionOptions);
-        (0, core_1.info)(`Selected reviewers for assignment: ${stringify(selected)}`);
+        (0, core_1.info)(`Selected additional reviewers for assignment: ${stringify(selected)}`);
         const assigned = await (0, exports.assignReviewers)(pullRequest, selected)(octokit);
         if (!assigned) {
             (0, core_1.error)(`Failed to assign reviewers: ${stringify(selected)}`);

--- a/dist/assign.js
+++ b/dist/assign.js
@@ -150,9 +150,8 @@ const selectReviewers = async (changedFiles, codeowners, teamMembers, options) =
             selectedUsers.add(selected);
         }
     }
-    (0, core_1.info)(`Selected ${assignees()} of ${reviewers} assignees.`);
     return {
-        count: assignees(),
+        count: selectedTeams.size + selectedUsers.size,
         teams: Array.from(selectedTeams),
         users: Array.from(selectedUsers),
     };

--- a/dist/assign.js
+++ b/dist/assign.js
@@ -123,6 +123,7 @@ const selectReviewers = async (changedFiles, codeowners, teamMembers, options) =
         (0, core_1.debug)(`Extracted team slug: ${teamSlug}.`);
         if (isTeam(selected) && assignIndividuals) {
             (0, core_1.debug)(`Assigning individuals from team: ${teamSlug}.`);
+            (0, core_1.debug)(`Possible teams are: ${stringify(teams)}.`);
             // If the set of all teams are exhausted we give up assigning teams.
             if (Object.keys(teams).length === 0) {
                 (0, core_1.debug)('Teams to assign is empty. Exiting.');

--- a/dist/assign.js
+++ b/dist/assign.js
@@ -129,11 +129,11 @@ const selectReviewers = async (changedFiles, codeowners, teamMembers, options) =
                 (0, core_1.debug)('Teams to assign is empty. Exiting.');
                 break;
             }
-            const randomTeamMember = randomize(teams?.[teamSlug])?.shift();
+            const randomTeamMember = randomize(teams?.[selected])?.shift();
             if (!randomTeamMember) {
                 // Remove the team from the stack of all team members have been extracted.
                 (0, core_1.debug)(`Did not find random team member. Removing team ${teamSlug} from possible teams to assign.`);
-                delete teams?.[teamSlug];
+                delete teams?.[selected];
                 randomGlobalCodeowners?.shift();
                 continue;
             }

--- a/dist/assign.js
+++ b/dist/assign.js
@@ -129,13 +129,14 @@ const selectReviewers = async (changedFiles, codeowners, teamMembers, options) =
                 break;
             }
             const randomTeamMember = randomize(teams?.[teamSlug])?.shift();
-            (0, core_1.debug)(`Found random team member: ${randomTeamMember}.`);
             if (!randomTeamMember) {
                 // Remove the team from the stack of all team members have been extracted.
                 (0, core_1.debug)(`Did not find random team member. Removing team ${teamSlug} from possible teams to assign.`);
                 delete teams?.[teamSlug];
+                randomGlobalCodeowners?.shift();
                 continue;
             }
+            (0, core_1.debug)(`Found random team member: ${randomTeamMember}.`);
             (0, core_1.info)(`Assigning '${randomTeamMember}' from assignee team '${teamSlug}'.`);
             selectedUsers.add(randomTeamMember);
         }

--- a/dist/assign.js
+++ b/dist/assign.js
@@ -115,7 +115,7 @@ const selectReviewers = async (changedFiles, codeowners, teamMembers, options) =
             break;
         const teamSlug = extractTeamSlug(selected);
         if (isTeam(selected) && assignIndividuals) {
-            // If the list of team members is exhausted we give up assigning team members.
+            // If the set of all teams are exhausted we give up assigning teams.
             if (Object.keys(teams).length === 0)
                 break;
             const randomTeamMember = randomize(teams?.[teamSlug])?.shift();

--- a/dist/assign.js
+++ b/dist/assign.js
@@ -162,7 +162,7 @@ const assignReviewers = (pullRequest, reviewers) => async (octokit) => {
     const { teams, users, count } = reviewers;
     if (count === 0) {
         (0, core_1.info)('No reviewers were selected. Skipping requesting reviewers.');
-        return;
+        return reviewers;
     }
     (0, core_1.info)(`Requesting ${count} reviewers via the GitHub API.`);
     const { data: assigned, status } = await octokit.rest.pulls.requestReviewers({

--- a/dist/assign.js
+++ b/dist/assign.js
@@ -159,8 +159,12 @@ const selectReviewers = async (changedFiles, codeowners, teamMembers, options) =
 exports.selectReviewers = selectReviewers;
 const assignReviewers = (pullRequest, reviewers) => async (octokit) => {
     const { repo, owner, number } = pullRequest;
-    const { teams, users } = reviewers;
-    (0, core_1.info)('Requesting reviewers via the GitHub API.');
+    const { teams, users, count } = reviewers;
+    if (count === 0) {
+        (0, core_1.info)('No reviewers were selected. Skipping requesting reviewers.');
+        return;
+    }
+    (0, core_1.info)(`Requesting ${count} reviewers via the GitHub API.`);
     const { data: assigned, status } = await octokit.rest.pulls.requestReviewers({
         owner,
         repo,

--- a/src/assign.test.ts
+++ b/src/assign.test.ts
@@ -435,7 +435,7 @@ describe('Reviewer selection', () => {
   it('does not select more than specified reviewers', async () => {
     const assigned = 4
     const expected: Assignees = {
-      count: assigned,
+      count: 0,
       teams: [],
       users: [],
     }

--- a/src/assign.test.ts
+++ b/src/assign.test.ts
@@ -444,7 +444,7 @@ describe('Reviewer selection', () => {
       assignIndividuals: false,
       reviewers: maxAssignees,
     }
-    const result = await selectReviewers(filesChanged, codeowners, undefined, options)
+    const result = await selectReviewers(filesChanged, codeowners, {}, options)
     expect(result).not.toBeNull()
     expect(result).toEqual(expected)
   })
@@ -456,7 +456,7 @@ describe('Reviewer selection', () => {
       assignIndividuals: false,
       reviewers: maxAssignees,
     }
-    const result = await selectReviewers(filesChanged, codeowners, undefined, options)
+    const result = await selectReviewers(filesChanged, codeowners, {}, options)
 
     expect(result).not.toBeNull()
     expect(result.count).toEqual(4)
@@ -475,7 +475,7 @@ describe('Reviewer selection', () => {
       assignIndividuals: false,
       reviewers: maxAssignees,
     }
-    const result = await selectReviewers(filesChanged, codeowners, undefined, options)
+    const result = await selectReviewers(filesChanged, codeowners, {}, options)
 
     expect(result).not.toBeNull()
     expect(result.count).toEqual(4)
@@ -494,7 +494,7 @@ describe('Reviewer selection', () => {
       reviewers: maxAssignees,
     }
 
-    const result = await selectReviewers(filesChanged, codeowners, undefined, options)
+    const result = await selectReviewers(filesChanged, codeowners, {}, options)
 
     expect(result).not.toBeNull()
     expect(result.count).toEqual(3)
@@ -512,7 +512,7 @@ describe('Reviewer selection', () => {
       reviewers: maxAssignees,
     }
 
-    await selectReviewers(filesChanged, codeowners, undefined, options)
+    await selectReviewers(filesChanged, codeowners, {}, options)
   })
 
   it('handles empty CODEOWNERS', async () => {
@@ -523,7 +523,7 @@ describe('Reviewer selection', () => {
       reviewers: maxAssignees,
     }
 
-    const result = await selectReviewers(filesChanged, [], undefined, options)
+    const result = await selectReviewers(filesChanged, [], {}, options)
 
     expect(result).toEqual({ count: 0, teams: [], users: [] })
   })

--- a/src/assign.test.ts
+++ b/src/assign.test.ts
@@ -512,7 +512,11 @@ describe('Reviewer selection', () => {
       reviewers: maxAssignees,
     }
 
-    await selectReviewers(filesChanged, codeowners, {}, options)
+    const result = await selectReviewers(filesChanged, codeowners, {}, options)
+    expect(result).not.toBeNull()
+    expect(result.count).toEqual(0)
+    expect(result.teams.length).toEqual(0)
+    expect(result.users.length).toEqual(0)
   })
 
   it('handles empty CODEOWNERS', async () => {

--- a/src/assign.test.ts
+++ b/src/assign.test.ts
@@ -16,6 +16,8 @@ import { CodeOwnersEntry } from 'codeowners-utils'
 beforeEach(() => {
   process.env['INPUT_REVIEWERS-TO-ASSIGN'] = '2'
   process.env['GITHUB_TOKEN'] = 'bla'
+  process.env['INPUT_ASSIGN-FROM-CHANGED-FILES'] = 'false'
+  process.env['ASSIGN-INDIVIDUALS-FROM-TEAMS'] = 'false'
 })
 
 describe('Input handling', () => {

--- a/src/assign.test.ts
+++ b/src/assign.test.ts
@@ -346,7 +346,7 @@ describe("Calling GitHub's API", () => {
     const expected = { count: userLogins.length + teamNames.length, teams: teamNames, users: userLogins }
 
     const assignees: Assignees = {
-      count: 0,
+      count: userLogins.length + teamNames.length,
       teams: teamNames,
       users: userLogins,
     }

--- a/src/assign.ts
+++ b/src/assign.ts
@@ -163,6 +163,7 @@ export const selectReviewers = async (
     debug(`Extracted team slug: ${teamSlug}.`)
     if (isTeam(selected) && assignIndividuals) {
       debug(`Assigning individuals from team: ${teamSlug}.`)
+      debug(`Possible teams are: ${stringify(teams)}.`)
       // If the set of all teams are exhausted we give up assigning teams.
       if (Object.keys(teams).length === 0) {
         debug('Teams to assign is empty. Exiting.')

--- a/src/assign.ts
+++ b/src/assign.ts
@@ -190,10 +190,9 @@ export const selectReviewers = async (
       selectedUsers.add(selected)
     }
   }
-  info(`Selected ${assignees()} of ${reviewers} assignees.`)
 
   return {
-    count: assignees(),
+    count: selectedTeams.size + selectedUsers.size,
     teams: Array.from(selectedTeams),
     users: Array.from(selectedUsers),
   }

--- a/src/assign.ts
+++ b/src/assign.ts
@@ -204,7 +204,7 @@ export const assignReviewers = (pullRequest: PullRequestInformation, reviewers: 
 
   if (count === 0) {
     info('No reviewers were selected. Skipping requesting reviewers.')
-    return
+    return reviewers
   }
 
   info(`Requesting ${count} reviewers via the GitHub API.`)

--- a/src/assign.ts
+++ b/src/assign.ts
@@ -4,7 +4,7 @@ import { existsSync, promises as fs } from 'fs'
 import { CodeOwnersEntry, parse } from 'codeowners-utils'
 import { Context } from '@actions/github/lib/context'
 import { Api } from '@octokit/plugin-rest-endpoint-methods/dist-types/types'
-import { ActionOptions, PullRequestInformation, Assignees, SelectionOptions, Teams } from './types'
+import { ActionOptions, PullRequestInformation, Assignees, SelectionOptions, TeamMembers } from './types'
 
 export const validPaths = ['CODEOWNERS', '.github/CODEOWNERS', 'docs/CODEOWNERS']
 
@@ -122,14 +122,14 @@ export const fetchTeamMembers = (organisation: string, codeowners: CodeOwnersEnt
     }),
   )
 
-  const joined = allTeams.reduce((acc: Teams, team: Teams) => ({ ...acc, ...team }), {})
+  const joined = allTeams.reduce((acc: TeamMembers, team: TeamMembers) => ({ ...acc, ...team }), {})
   return joined
 }
 
 export const selectReviewers = async (
   changedFiles: string[],
   codeowners: CodeOwnersEntry[],
-  ownerTeams: Teams,
+  ownerTeams: TeamMembers,
   options: SelectionOptions,
 ) => {
   const { assignedReviewers, reviewers, assignIndividuals } = options
@@ -141,7 +141,7 @@ export const selectReviewers = async (
   const randomGlobalCodeowner = (owners?: string[]) => (assignIndividuals ? owners?.[0] : owners?.shift())
 
   const stack = JSON.parse(JSON.stringify(codeowners)) as CodeOwnersEntry[] //Poor man's deep clone.
-  const teams = ownerTeams && (JSON.parse(JSON.stringify(ownerTeams)) as Teams)
+  const teams = ownerTeams && (JSON.parse(JSON.stringify(ownerTeams)) as TeamMembers)
   const globalCodeowners = stack.find(owner => owner.pattern === '*')?.owners
 
   while (assignees() < reviewers) {

--- a/src/assign.ts
+++ b/src/assign.ts
@@ -170,11 +170,11 @@ export const selectReviewers = async (
         break
       }
 
-      const randomTeamMember = randomize(teams?.[teamSlug])?.shift()
+      const randomTeamMember = randomize(teams?.[selected])?.shift()
       if (!randomTeamMember) {
         // Remove the team from the stack of all team members have been extracted.
         debug(`Did not find random team member. Removing team ${teamSlug} from possible teams to assign.`)
-        delete teams?.[teamSlug]
+        delete teams?.[selected]
         randomGlobalCodeowners?.shift()
         continue
       }

--- a/src/assign.ts
+++ b/src/assign.ts
@@ -151,8 +151,13 @@ export const selectReviewers = async (
 
     const teamSlug = extractTeamSlug(selected)
     if (isTeam(selected) && assignIndividuals) {
+      if (Object.keys(teams).length === 0) break
+
       const randomTeamMember = randomize(teams?.[teamSlug])?.shift()
-      if (!randomTeamMember) break
+      if (!randomTeamMember) {
+        delete teams?.[teamSlug]
+        continue
+      }
 
       info(`Assigning '${randomTeamMember}' from assignee team '${teamSlug}'.`)
       selectedUsers.add(randomTeamMember)

--- a/src/assign.ts
+++ b/src/assign.ts
@@ -200,9 +200,14 @@ export const selectReviewers = async (
 
 export const assignReviewers = (pullRequest: PullRequestInformation, reviewers: Assignees) => async (octokit: Api) => {
   const { repo, owner, number } = pullRequest
-  const { teams, users } = reviewers
+  const { teams, users, count } = reviewers
 
-  info('Requesting reviewers via the GitHub API.')
+  if (count === 0) {
+    info('No reviewers were selected. Skipping requesting reviewers.')
+    return
+  }
+
+  info(`Requesting ${count} reviewers via the GitHub API.`)
   const { data: assigned, status } = await octokit.rest.pulls.requestReviewers({
     owner,
     repo,
@@ -215,7 +220,7 @@ export const assignReviewers = (pullRequest: PullRequestInformation, reviewers: 
   const requestedTeams = assigned.requested_teams?.map(team => team.name)
 
   if (requestedReviewers && requestedTeams) {
-    const requested: Assignees = {
+    const requested = {
       count: requestedReviewers.length + requestedTeams.length,
       teams: requestedTeams,
       users: requestedReviewers,

--- a/src/assign.ts
+++ b/src/assign.ts
@@ -170,13 +170,14 @@ export const selectReviewers = async (
       }
 
       const randomTeamMember = randomize(teams?.[teamSlug])?.shift()
-      debug(`Found random team member: ${randomTeamMember}.`)
       if (!randomTeamMember) {
         // Remove the team from the stack of all team members have been extracted.
         debug(`Did not find random team member. Removing team ${teamSlug} from possible teams to assign.`)
         delete teams?.[teamSlug]
+        randomGlobalCodeowners?.shift()
         continue
       }
+      debug(`Found random team member: ${randomTeamMember}.`)
 
       info(`Assigning '${randomTeamMember}' from assignee team '${teamSlug}'.`)
       selectedUsers.add(randomTeamMember)

--- a/src/assign.ts
+++ b/src/assign.ts
@@ -265,7 +265,7 @@ export const run = async () => {
     const changedFiles = await extractChangedFiles(assignFromChanges, pullRequest)(octokit)
     info('Selecting reviewers for assignment.')
     const selected = await selectReviewers(changedFiles, codeowners, teams, selectionOptions)
-    info(`Selected reviewers for assignment: ${stringify(selected)}`)
+    info(`Selected additional reviewers for assignment: ${stringify(selected)}`)
 
     const assigned = await assignReviewers(pullRequest, selected)(octokit)
     if (!assigned) {

--- a/src/assign.ts
+++ b/src/assign.ts
@@ -154,7 +154,7 @@ export const selectReviewers = async (
 
     const teamSlug = extractTeamSlug(selected)
     if (isTeam(selected) && assignIndividuals) {
-      // If the list of team members is exhausted we give up assigning team members.
+      // If the set of all teams are exhausted we give up assigning teams.
       if (Object.keys(teams).length === 0) break
 
       const randomTeamMember = randomize(teams?.[teamSlug])?.shift()

--- a/src/assign.ts
+++ b/src/assign.ts
@@ -272,11 +272,6 @@ export const run = async () => {
     info(`Selected additional reviewers for assignment: ${stringify(selected)}`)
 
     const assigned = await assignReviewers(pullRequest, selected)(octokit)
-    if (!assigned) {
-      error(`Failed to assign reviewers: ${stringify(selected)}`)
-      process.exit(1)
-    }
-
     setOutput('assigned-codeowners', stringify(assigned))
     info(`Assigned reviewers: ${stringify(assigned)}`)
   } catch (error: unknown) {

--- a/src/assign.ts
+++ b/src/assign.ts
@@ -190,6 +190,7 @@ export const selectReviewers = async (
       selectedUsers.add(selected)
     }
   }
+  info(`Selected ${assignees()} of ${reviewers} assignees.`)
 
   return {
     count: assignees(),

--- a/src/assign.ts
+++ b/src/assign.ts
@@ -231,7 +231,7 @@ export const assignReviewers = (pullRequest: PullRequestInformation, reviewers: 
     return requested
   }
 
-  return undefined
+  return reviewers
 }
 
 export const run = async () => {

--- a/src/assign.ts
+++ b/src/assign.ts
@@ -129,7 +129,7 @@ export const fetchTeamMembers = (organisation: string, codeowners: CodeOwnersEnt
 export const selectReviewers = async (
   changedFiles: string[],
   codeowners: CodeOwnersEntry[],
-  ownerTeams: TeamMembers,
+  teamMembers: TeamMembers,
   options: SelectionOptions,
 ) => {
   const { assignedReviewers, reviewers, assignIndividuals } = options
@@ -141,7 +141,7 @@ export const selectReviewers = async (
   const randomGlobalCodeowner = (owners?: string[]) => (assignIndividuals ? owners?.[0] : owners?.shift())
 
   const stack = JSON.parse(JSON.stringify(codeowners)) as CodeOwnersEntry[] //Poor man's deep clone.
-  const teams = ownerTeams && (JSON.parse(JSON.stringify(ownerTeams)) as TeamMembers)
+  const teams = teamMembers && (JSON.parse(JSON.stringify(teamMembers)) as TeamMembers)
   const globalCodeowners = stack.find(owner => owner.pattern === '*')?.owners
 
   while (assignees() < reviewers) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,3 +24,7 @@ export interface SelectionOptions {
   reviewers: number
   assignIndividuals: boolean
 }
+
+export interface Teams {
+  [teamName: string]: string[]
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,6 +25,6 @@ export interface SelectionOptions {
   assignIndividuals: boolean
 }
 
-export interface Teams {
+export interface TeamMembers {
   [teamName: string]: string[]
 }


### PR DESCRIPTION
There was a bug present in the individual user assignment from teams. 

If a global `CODEOWNER` team was picked for assignment, this team would never be looked at again (since it was popped from the stack of teams). This meant that a single individual would be picked from the team and then the assignment loop would end. 

This fixes that by:
- fetching all `CODEOWNERS` teams and their members if individuals should be assigned (this prevents a subtle infinite loop with one-member teams) before running
- creating a stack from teams and their members and removes individual members from teams when they are assigned to ensure assignment happens as expected

